### PR TITLE
fix: fixed PointMaterial on WebGL1

### DIFF
--- a/src/core/PointMaterial.tsx
+++ b/src/core/PointMaterial.tsx
@@ -15,11 +15,16 @@ declare global {
 export class PointMaterialImpl extends THREE.PointsMaterial {
   constructor(props) {
     super(props)
-    this.onBeforeCompile = (shader) => {
+    this.onBeforeCompile = (shader, renderer) => {
+      const { isWebGL2 } = renderer.capabilities
       shader.fragmentShader = shader.fragmentShader.replace(
         '#include <output_fragment>',
         `
-        #include <output_fragment>
+        ${
+          !isWebGL2
+            ? '#extension GL_OES_standard_derivatives : enable\n#include <output_fragment>'
+            : '#include <output_fragment>'
+        }
       vec2 cxy = 2.0 * gl_PointCoord - 1.0;
       float r = dot(cxy, cxy);
       float delta = fwidth(r);     


### PR DESCRIPTION
PointMaterial is not working on the browser that are using previous version of WebGL.
It's because 'GL_OES_standard_derivatives' extension. In WebGL2, this extension has been included in core.
For WebGL1 support, we need to enable it first. We also need to be sure to not enable it on WebGL2,
because it will throw an error.